### PR TITLE
👷 refactor call_depositions to ask if sandbox

### DIFF
--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -14,7 +14,7 @@ import re
 
 
 def tests_call_depositions():
-    obtained = call_depositions()
+    obtained = call_depositions(is_sandbox=True)
     with open("data.json", "w", encoding="utf-8") as f:
         json.dump(obtained.json(), f, ensure_ascii=False, indent=4)
     assert obtained.status_code == 200

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -1,7 +1,7 @@
 import requests
 import os
 import json
-import pathlib 
+import pathlib
 from datetime import date
 from zenodo_api.url_selector import url_selector
 

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -1,7 +1,7 @@
 import requests
 import os
 import json
-import pathlib
+import pathlib 
 from datetime import date
 from zenodo_api.url_selector import url_selector
 

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -5,10 +5,11 @@ import pathlib
 from datetime import date
 
 
-def call_depositions():
+def call_depositions(is_sandbox):
     ACCESS_TOKEN = load_access_token()
+    url_api = url_selector(is_sandbox)
     empty_upload = requests.get(
-        "https://sandbox.zenodo.org/api/deposit/depositions",
+        url_api + "/deposit/depositions",
         [("access_token", ACCESS_TOKEN), ("size", 200), ("all_versions", "true")],
     )
     return empty_upload

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -3,7 +3,7 @@ import os
 import json
 import pathlib
 from datetime import date
-
+from zenodo_api.url_selector import url_selector
 
 def call_depositions(is_sandbox):
     ACCESS_TOKEN = load_access_token()

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -5,6 +5,7 @@ import pathlib
 from datetime import date
 from zenodo_api.url_selector import url_selector
 
+
 def call_depositions(is_sandbox):
     ACCESS_TOKEN = load_access_token()
     url_api = url_selector(is_sandbox)


### PR DESCRIPTION
Refactorizacion de la función **`call_depositions()`**. Anteriormente la función no requería parametros para ejecutarse y asumía en el url que se trabajaba en el **sandbox**. Refactorizamos tanto la funcion como su **prueba** mediante "`xxfuncion`" para incluir el booleano `is_sandbox` como parametro necesario.  `is_sandbox` define el url mediante `url_selector(is_sandbox)`.

`call_depositions()` -> `call_depositions(is_sandbox)`

![image](https://github.com/user-attachments/assets/76312214-dc61-405d-bf87-0edb88d5056e)

Inicié con la función mas sencilla para probar los PR. Me dicen que opinan y lo aplico a los demás tomando en cuenta la retroalimentación. 

pd. Voy viendo que olvidé importar el `url_selector`, por ahora no corregiré para no saturar aquí con otro commit. 