### PR TITLE
🏗️ refactor `upload_files.py` functions to ask if sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-06-04
+
+### Fixed
+- all functions in `upload_files.py` and `new_version.py` that use urls for responses now require the `is_sandbox` boolean parameter
+
 ## [0.2.1] - 2025-05-21
 
 ### Fixed

--- a/tests/test_new_version.py
+++ b/tests/test_new_version.py
@@ -1,7 +1,7 @@
 from zenodo_api.new_version import (
     create_draft_of_new_version,
     get_latest_version_id,
-    upload_file_in_new_deposition,
+    xxupload_file_in_new_deposition,
     open_new_deposition,
 )
 from zenodo_api.upload_files import load_access_token
@@ -44,7 +44,7 @@ def test_upload_file_in_new_deposition():
 
     new_deposition = open_new_deposition(concept_rec_id, is_sandbox)
     new_deposition_json = new_deposition.json()
-    obtained = upload_file_in_new_deposition(new_deposition_json, file_path)
+    obtained = xxupload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox)
     assert obtained.status_code == 201
     time.sleep(1)
     latest_draft_link = new_deposition_json["links"]["latest_draft"]

--- a/tests/test_new_version.py
+++ b/tests/test_new_version.py
@@ -1,7 +1,7 @@
 from zenodo_api.new_version import (
     create_draft_of_new_version,
     get_latest_version_id,
-    xxupload_file_in_new_deposition,
+    upload_file_in_new_deposition,
     open_new_deposition,
 )
 from zenodo_api.upload_files import load_access_token
@@ -44,7 +44,7 @@ def test_upload_file_in_new_deposition():
 
     new_deposition = open_new_deposition(concept_rec_id, is_sandbox)
     new_deposition_json = new_deposition.json()
-    obtained = xxupload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox)
+    obtained = upload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox)
     assert obtained.status_code == 201
     time.sleep(1)
     latest_draft_link = new_deposition_json["links"]["latest_draft"]

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -7,7 +7,7 @@ from zenodo_api.upload_files import (
     load_access_token,
     create_deposition_in_new_record,
     upload_file_in_new_record,
-    upload_metadata_in_new_record,
+    xxupload_metadata_in_new_record,
 )
 from zenodo_api.retrieve import search_deposition_by_title
 import re
@@ -53,7 +53,7 @@ def tests_upload_metadata():
             "description": "This is my first upload",
         }
     }
-    obtained = upload_metadata_in_new_record(data_dict)
+    obtained = xxupload_metadata_in_new_record(data_dict, is_sandbox=True)
     assert obtained.status_code == 200
 
     obtained_json = obtained.json()

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -26,7 +26,7 @@ def test_load_access_token():
 
 
 def test_create_empty_upload():
-    obtained = create_deposition_in_new_record()
+    obtained = create_deposition_in_new_record(is_sandbox=True)
     assert obtained.status_code == 201
 
 

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -5,7 +5,7 @@ import time
 from zenodo_api.upload_files import (
     call_depositions,
     load_access_token,
-    create_deposition_in_new_record,
+    xxcreate_deposition_in_new_record,
     upload_file_in_new_record,
     upload_metadata_in_new_record,
 )
@@ -26,7 +26,7 @@ def test_load_access_token():
 
 
 def test_create_empty_upload():
-    obtained = create_deposition_in_new_record(is_sandbox=True)
+    obtained = xxcreate_deposition_in_new_record(is_sandbox=True)
     assert obtained.status_code == 201
 
 

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -32,7 +32,7 @@ def test_create_empty_upload():
 
 def tests_upload_new_file():
     file_path = "tests/data/tests_file.txt"
-    obtained = upload_file_in_new_record(file_path)
+    obtained = upload_file_in_new_record(file_path, is_sandbox=True)
     assert obtained["response_upload"].status_code == 201
     assert "latest_draft" in obtained.keys()
 

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -7,7 +7,7 @@ from zenodo_api.upload_files import (
     load_access_token,
     create_deposition_in_new_record,
     upload_file_in_new_record,
-    xxupload_metadata_in_new_record,
+    upload_metadata_in_new_record,
 )
 from zenodo_api.retrieve import search_deposition_by_title
 import re
@@ -53,7 +53,7 @@ def tests_upload_metadata():
             "description": "This is my first upload",
         }
     }
-    obtained = xxupload_metadata_in_new_record(data_dict, is_sandbox=True)
+    obtained = upload_metadata_in_new_record(data_dict, is_sandbox=True)
     assert obtained.status_code == 200
 
     obtained_json = obtained.json()

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -5,7 +5,7 @@ import time
 from zenodo_api.upload_files import (
     call_depositions,
     load_access_token,
-    xxcreate_deposition_in_new_record,
+    create_deposition_in_new_record,
     upload_file_in_new_record,
     upload_metadata_in_new_record,
 )
@@ -26,7 +26,7 @@ def test_load_access_token():
 
 
 def test_create_empty_upload():
-    obtained = xxcreate_deposition_in_new_record(is_sandbox=True)
+    obtained = create_deposition_in_new_record(is_sandbox=True)
     assert obtained.status_code == 201
 
 

--- a/zenodo_api/__init__.py
+++ b/zenodo_api/__init__.py
@@ -1,6 +1,6 @@
 """A template Python module"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 from .upload_files import *  # noqa
 from .url_selector import *  # noqa
 from .retrieve import *  # noqa

--- a/zenodo_api/new_version.py
+++ b/zenodo_api/new_version.py
@@ -27,7 +27,8 @@ def open_new_deposition(concept_rec_id, is_test):
 
 
 def upload_file_in_new_deposition(new_deposition_json, file_path):
-    upload_new_deposition_metadata(new_deposition_json)
+    is_sandbox = True
+    xxupload_new_deposition_metadata(new_deposition_json, is_sandbox)
     delete_previous_files(new_deposition_json)
     bucket_url = new_deposition_json["links"]["bucket"]
     response = upload_file(bucket_url, file_path)
@@ -55,10 +56,10 @@ def create_draft_of_new_version(latest_version_id, is_sandbox):
     return response
 
 
-def upload_new_deposition_metadata(new_deposition_json):
+def xxupload_new_deposition_metadata(new_deposition_json, is_sandbox):
     new_deposition_id = new_deposition_json["id"]
     previous_metadata = new_deposition_json["metadata"]
-    upload_metadata(previous_metadata, new_deposition_id, is_sandbox=True)
+    upload_metadata(previous_metadata, new_deposition_id, is_sandbox)
 
 
 def delete_previous_files(new_deposition_json):

--- a/zenodo_api/new_version.py
+++ b/zenodo_api/new_version.py
@@ -7,7 +7,7 @@ def _publish_new_version(concept_rec_id, file_path, is_sandbox):
     new_deposition = open_new_deposition(concept_rec_id, is_sandbox)
 
     new_deposition_json = new_deposition.json()
-    xxupload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox)
+    upload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox)
 
     access_token = load_access_token()
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -26,7 +26,7 @@ def open_new_deposition(concept_rec_id, is_test):
     return new_deposition
 
 
-def xxupload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox):
+def upload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox):
     upload_new_deposition_metadata(new_deposition_json, is_sandbox)
     delete_previous_files(new_deposition_json)
     bucket_url = new_deposition_json["links"]["bucket"]

--- a/zenodo_api/new_version.py
+++ b/zenodo_api/new_version.py
@@ -1,5 +1,5 @@
 import requests
-from zenodo_api.upload_files import load_access_token, upload_file, upload_metadata
+from zenodo_api.upload_files import load_access_token, upload_file, xxupload_metadata
 from zenodo_api.url_selector import url_selector
 
 
@@ -58,7 +58,7 @@ def create_draft_of_new_version(latest_version_id, is_sandbox):
 def upload_new_deposition_metadata(new_deposition_json):
     new_deposition_id = new_deposition_json["id"]
     previous_metadata = new_deposition_json["metadata"]
-    upload_metadata(previous_metadata, new_deposition_id)
+    xxupload_metadata(previous_metadata, new_deposition_id, is_sandbox=True)
 
 
 def delete_previous_files(new_deposition_json):

--- a/zenodo_api/new_version.py
+++ b/zenodo_api/new_version.py
@@ -1,5 +1,5 @@
 import requests
-from zenodo_api.upload_files import load_access_token, upload_file, xxupload_metadata
+from zenodo_api.upload_files import load_access_token, upload_file, upload_metadata
 from zenodo_api.url_selector import url_selector
 
 
@@ -58,7 +58,7 @@ def create_draft_of_new_version(latest_version_id, is_sandbox):
 def upload_new_deposition_metadata(new_deposition_json):
     new_deposition_id = new_deposition_json["id"]
     previous_metadata = new_deposition_json["metadata"]
-    xxupload_metadata(previous_metadata, new_deposition_id, is_sandbox=True)
+    upload_metadata(previous_metadata, new_deposition_id, is_sandbox=True)
 
 
 def delete_previous_files(new_deposition_json):

--- a/zenodo_api/new_version.py
+++ b/zenodo_api/new_version.py
@@ -28,7 +28,7 @@ def open_new_deposition(concept_rec_id, is_test):
 
 def upload_file_in_new_deposition(new_deposition_json, file_path):
     is_sandbox = True
-    xxupload_new_deposition_metadata(new_deposition_json, is_sandbox)
+    upload_new_deposition_metadata(new_deposition_json, is_sandbox)
     delete_previous_files(new_deposition_json)
     bucket_url = new_deposition_json["links"]["bucket"]
     response = upload_file(bucket_url, file_path)
@@ -56,7 +56,7 @@ def create_draft_of_new_version(latest_version_id, is_sandbox):
     return response
 
 
-def xxupload_new_deposition_metadata(new_deposition_json, is_sandbox):
+def upload_new_deposition_metadata(new_deposition_json, is_sandbox):
     new_deposition_id = new_deposition_json["id"]
     previous_metadata = new_deposition_json["metadata"]
     upload_metadata(previous_metadata, new_deposition_id, is_sandbox)

--- a/zenodo_api/new_version.py
+++ b/zenodo_api/new_version.py
@@ -7,7 +7,7 @@ def _publish_new_version(concept_rec_id, file_path, is_sandbox):
     new_deposition = open_new_deposition(concept_rec_id, is_sandbox)
 
     new_deposition_json = new_deposition.json()
-    upload_file_in_new_deposition(new_deposition_json, file_path)
+    xxupload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox)
 
     access_token = load_access_token()
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -26,8 +26,7 @@ def open_new_deposition(concept_rec_id, is_test):
     return new_deposition
 
 
-def upload_file_in_new_deposition(new_deposition_json, file_path):
-    is_sandbox = True
+def xxupload_file_in_new_deposition(new_deposition_json, file_path, is_sandbox):
     upload_new_deposition_metadata(new_deposition_json, is_sandbox)
     delete_previous_files(new_deposition_json)
     bucket_url = new_deposition_json["links"]["bucket"]

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -20,10 +20,15 @@ def load_access_token():
     return os.environ.get("ACCESS_TOKEN")
 
 
-def create_deposition_in_new_record():
+def create_deposition_in_new_record(is_sandbox):
+    return xxcreate_deposition_in_new_record(is_sandbox)
+
+
+def xxcreate_deposition_in_new_record(is_sandbox):
+    url_api = url_selector(is_sandbox)
     headers = {"Authorization": f"Bearer {load_access_token()}", "Content-Type": "application/json"}
     response = requests.post(
-        "https://sandbox.zenodo.org/api/deposit/depositions",
+        url_api + "/deposit/depositions",
         json={},
         headers=headers,
     )
@@ -31,7 +36,8 @@ def create_deposition_in_new_record():
 
 
 def upload_file_in_new_record(file_path):
-    empty_upload = create_deposition_in_new_record()
+    is_sandbox = True
+    empty_upload = create_deposition_in_new_record(is_sandbox)
 
     bucket_url = empty_upload.json()["links"]["bucket"]
 
@@ -56,7 +62,8 @@ def upload_file(bucket_url, file_path):
 
 
 def upload_metadata_in_new_record(data_dict):
-    empty_upload = create_deposition_in_new_record()
+    is_sandbox = True
+    empty_upload = create_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
     response = upload_metadata(data_dict["metadata"], deposition_id)
     return response

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -59,11 +59,11 @@ def upload_file(bucket_url, file_path):
 def upload_metadata_in_new_record(data_dict, is_sandbox):
     empty_upload = create_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
-    response = xxupload_metadata(data_dict["metadata"], deposition_id, is_sandbox)
+    response = upload_metadata(data_dict["metadata"], deposition_id, is_sandbox)
     return response
 
 
-def xxupload_metadata(previous_metadata, deposition_id, is_sandbox):
+def upload_metadata(previous_metadata, deposition_id, is_sandbox):
     default_metadata = {
         "creators": [{"name": "Grupo de Ecología y Conservación de Islas"}],
         "publication_date": str(date.today()),

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -31,12 +31,7 @@ def create_deposition_in_new_record(is_sandbox):
     return response
 
 
-def upload_file_in_new_record(file_path):
-    is_sandbox = True
-    return xxupload_file_in_new_record(file_path, is_sandbox)
-
-
-def xxupload_file_in_new_record(file_path, is_sandbox):
+def upload_file_in_new_record(file_path, is_sandbox):
     empty_upload = create_deposition_in_new_record(is_sandbox)
 
     bucket_url = empty_upload.json()["links"]["bucket"]

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -20,7 +20,7 @@ def load_access_token():
     return os.environ.get("ACCESS_TOKEN")
 
 
-def xxcreate_deposition_in_new_record(is_sandbox):
+def create_deposition_in_new_record(is_sandbox):
     url_api = url_selector(is_sandbox)
     headers = {"Authorization": f"Bearer {load_access_token()}", "Content-Type": "application/json"}
     response = requests.post(
@@ -33,7 +33,7 @@ def xxcreate_deposition_in_new_record(is_sandbox):
 
 def upload_file_in_new_record(file_path):
     is_sandbox = True
-    empty_upload = xxcreate_deposition_in_new_record(is_sandbox)
+    empty_upload = create_deposition_in_new_record(is_sandbox)
 
     bucket_url = empty_upload.json()["links"]["bucket"]
 
@@ -59,7 +59,7 @@ def upload_file(bucket_url, file_path):
 
 def upload_metadata_in_new_record(data_dict):
     is_sandbox = True
-    empty_upload = xxcreate_deposition_in_new_record(is_sandbox)
+    empty_upload = create_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
     response = upload_metadata(data_dict["metadata"], deposition_id)
     return response

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -56,8 +56,7 @@ def upload_file(bucket_url, file_path):
     return response_upload
 
 
-def upload_metadata_in_new_record(data_dict):
-    is_sandbox = True
+def xxupload_metadata_in_new_record(data_dict, is_sandbox):
     empty_upload = create_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
     response = upload_metadata(data_dict["metadata"], deposition_id)

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -20,10 +20,6 @@ def load_access_token():
     return os.environ.get("ACCESS_TOKEN")
 
 
-def create_deposition_in_new_record(is_sandbox):
-    return xxcreate_deposition_in_new_record(is_sandbox)
-
-
 def xxcreate_deposition_in_new_record(is_sandbox):
     url_api = url_selector(is_sandbox)
     headers = {"Authorization": f"Bearer {load_access_token()}", "Content-Type": "application/json"}
@@ -37,7 +33,7 @@ def xxcreate_deposition_in_new_record(is_sandbox):
 
 def upload_file_in_new_record(file_path):
     is_sandbox = True
-    empty_upload = create_deposition_in_new_record(is_sandbox)
+    empty_upload = xxcreate_deposition_in_new_record(is_sandbox)
 
     bucket_url = empty_upload.json()["links"]["bucket"]
 
@@ -63,7 +59,7 @@ def upload_file(bucket_url, file_path):
 
 def upload_metadata_in_new_record(data_dict):
     is_sandbox = True
-    empty_upload = create_deposition_in_new_record(is_sandbox)
+    empty_upload = xxcreate_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
     response = upload_metadata(data_dict["metadata"], deposition_id)
     return response

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -33,6 +33,10 @@ def create_deposition_in_new_record(is_sandbox):
 
 def upload_file_in_new_record(file_path):
     is_sandbox = True
+    return xxupload_file_in_new_record(file_path, is_sandbox)
+
+
+def xxupload_file_in_new_record(file_path, is_sandbox):
     empty_upload = create_deposition_in_new_record(is_sandbox)
 
     bucket_url = empty_upload.json()["links"]["bucket"]

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -56,7 +56,7 @@ def upload_file(bucket_url, file_path):
     return response_upload
 
 
-def xxupload_metadata_in_new_record(data_dict, is_sandbox):
+def upload_metadata_in_new_record(data_dict, is_sandbox):
     empty_upload = create_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
     response = upload_metadata(data_dict["metadata"], deposition_id)

--- a/zenodo_api/upload_files.py
+++ b/zenodo_api/upload_files.py
@@ -59,11 +59,11 @@ def upload_file(bucket_url, file_path):
 def upload_metadata_in_new_record(data_dict, is_sandbox):
     empty_upload = create_deposition_in_new_record(is_sandbox)
     deposition_id = empty_upload.json()["id"]
-    response = upload_metadata(data_dict["metadata"], deposition_id)
+    response = xxupload_metadata(data_dict["metadata"], deposition_id, is_sandbox)
     return response
 
 
-def upload_metadata(previous_metadata, deposition_id):
+def xxupload_metadata(previous_metadata, deposition_id, is_sandbox):
     default_metadata = {
         "creators": [{"name": "Grupo de Ecología y Conservación de Islas"}],
         "publication_date": str(date.today()),
@@ -71,8 +71,9 @@ def upload_metadata(previous_metadata, deposition_id):
     previous_metadata.update(default_metadata)
     new_metadata = {"metadata": previous_metadata}
     headers = {"Authorization": f"Bearer {load_access_token()}", "Content-Type": "application/json"}
+    url_api = url_selector(is_sandbox)
     response = requests.put(
-        f"https://sandbox.zenodo.org/api/deposit/depositions/{deposition_id}",
+        url_api + f"/deposit/depositions/{deposition_id}",
         data=json.dumps(new_metadata),
         headers=headers,
     )


### PR DESCRIPTION
Refactorización de las funciones:
- [x]  `create_deposition_in_new_record`
- [x]  `upload_metadata`

Definidas en el archivo `upload_files.py`.
Refactorización mediante "`xxfuncion`" para incluir el booleano `is_sandbox` como parámetro requerido. `is_sandbox` define el URL mediante `url_selector(is_sandbox)`.

🔵 Iniciamos con el commit: _👷 refactor `create_deposition_in_new_record` to ask if sandbox_. Lo cual a su vez requirió modificar 
- [x]  `upload_file_in_new_record`
- [x] `upload_metadata_in_new_record`

asumiendo `is_sandbox = True` por ahora:
![image](https://github.com/user-attachments/assets/8d5fa817-d05c-4f8a-a235-7b7d16085297)

Habrá que refactorizar también las dos anteriores para recibir `is_sandbox` como parámetro.
